### PR TITLE
Этап 8: возврат на CSS Modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       dockerfile: Dockerfile
     image: courseboardreact_app
     working_dir: /app
-    environment:
-      CHOKIDAR_USEPOLLING: "true"
     ports:
       - "5173:5173"
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,9 @@
         "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
-        "@tailwindcss/vite": "^4.2.4",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
-        "tailwindcss": "^4.2.4",
         "typescript": "^5.6.3",
         "vite": "^5.4.10"
       }
@@ -345,278 +343,6 @@
         "linux"
       ]
     },
-    "node_modules/@tailwindcss/node": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
-      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.19.0",
-        "jiti": "^2.6.1",
-        "lightningcss": "1.32.0",
-        "magic-string": "^0.30.21",
-        "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.4"
-      }
-    },
-    "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
-      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-x64": "4.2.4",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
-      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
-      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
-      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
-      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
-      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
-      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
-      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
-      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
-      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
-      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.8.1",
-        "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.1",
-        "@tybys/wasm-util": "^0.10.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
-      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
-      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/vite": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
-      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tailwindcss/node": "4.2.4",
-        "@tailwindcss/oxide": "4.2.4",
-        "tailwindcss": "4.2.4"
-      },
-      "peerDependencies": {
-        "vite": "^5.2.0 || ^6 || ^7 || ^8"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "dev": true,
@@ -794,6 +520,8 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -802,20 +530,6 @@
       "version": "1.5.344",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -870,23 +584,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -919,6 +616,8 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -956,6 +655,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -977,6 +677,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -998,6 +699,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1019,6 +721,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1040,6 +743,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1061,6 +765,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1082,6 +787,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1103,6 +809,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1124,6 +831,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1145,6 +853,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1166,6 +875,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1190,16 +900,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
@@ -1382,27 +1082,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tapable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,9 @@
     "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.2.4",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
-    "tailwindcss": "^4.2.4",
     "typescript": "^5.6.3",
     "vite": "^5.4.10"
   }

--- a/src/app/layout/AppLayout.tsx
+++ b/src/app/layout/AppLayout.tsx
@@ -4,9 +4,9 @@ import {Header} from '../../components/Header';
 
 export function AppLayout() {
   return (
-    <div className="layout-shell">
+    <div className="layout">
       <Header />
-      <main className="page-container">
+      <main className="content">
         <Outlet />
       </main>
     </div>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,10 +1,11 @@
 import {Navigation} from '../Navigation';
+import styles from './header.module.css';
 
 export function Header() {
   return (
-    <header className="header-shell">
-      <div className="header-inner">
-        <strong className="brand-mark">Courseboard React</strong>
+    <header className={styles.header}>
+      <div className={styles.inner}>
+        <strong className={styles.brand}>Courseboard React</strong>
         <Navigation />
       </div>
     </header>

--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -1,12 +1,14 @@
+import styles from './loader.module.css';
+
 interface LoaderProps {
   label?: string;
 }
 
 export function Loader({label = 'Загрузка данных...'}: LoaderProps) {
   return (
-    <div className="loader-panel">
-      <div className="loader-spinner" aria-hidden="true" />
-      <p className="m-0">{label}</p>
+    <div className={styles.loader} role="status" aria-live="polite">
+      <div className={styles.spinner} aria-hidden="true" />
+      <p className={styles.label}>{label}</p>
     </div>
   );
 }

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -1,13 +1,14 @@
 import {NavLink} from 'react-router-dom';
+import styles from './navigation.module.css';
 
 function getLinkClass(isActive: boolean) {
-  return isActive ? 'nav-pill nav-pill-active' : 'nav-pill';
+  return isActive ? `${styles.link} ${styles.active}` : styles.link;
 }
 
 export function Navigation() {
   return (
     <nav aria-label="Основная навигация">
-      <ul className="nav-list">
+      <ul className={styles.list}>
         <li>
           <NavLink to="/" className={({isActive}) => getLinkClass(isActive)}>
             Главная

--- a/src/components/StateMessage/index.tsx
+++ b/src/components/StateMessage/index.tsx
@@ -1,3 +1,5 @@
+import styles from './state-message.module.css';
+
 interface StateMessageProps {
   title: string;
   description: string;
@@ -7,11 +9,11 @@ interface StateMessageProps {
 
 export function StateMessage({title, description, actionLabel, onAction}: StateMessageProps) {
   return (
-    <section className="state-panel">
-      <h1 className="state-title">{title}</h1>
-      <p className="state-text">{description}</p>
+    <section className={styles.message}>
+      <h1 className={styles.title}>{title}</h1>
+      <p className={styles.text}>{description}</p>
       {actionLabel && onAction ? (
-        <button className="action-button" type="button" onClick={() => void onAction()}>
+        <button className={styles.action} type="button" onClick={() => void onAction()}>
           {actionLabel}
         </button>
       ) : null}

--- a/src/modules/courses/components/CourseCard.tsx
+++ b/src/modules/courses/components/CourseCard.tsx
@@ -1,6 +1,7 @@
 import {Link} from 'react-router-dom';
 
 import type {CourseListItem} from '../types';
+import styles from './course-card.module.css';
 
 interface CourseCardProps {
   course: CourseListItem;
@@ -8,14 +9,14 @@ interface CourseCardProps {
 
 export function CourseCard({course}: CourseCardProps) {
   return (
-    <article className="course-card">
-      <h2 className="course-title">
-        <Link className="course-link" to={`/courses/${course.id}`}>
+    <article className={styles.card}>
+      <h2 className={styles.title}>
+        <Link className={styles.link} to={`/courses/${course.id}`}>
           {course.title}
         </Link>
       </h2>
-      <p className="course-summary">{course.summary}</p>
-      <strong className="course-level">Уровень: {course.level}</strong>
+      <p className={styles.summary}>{course.summary}</p>
+      <strong className={styles.level}>Уровень: {course.level}</strong>
     </article>
   );
 }

--- a/src/pages/AboutPage/index.tsx
+++ b/src/pages/AboutPage/index.tsx
@@ -1,9 +1,11 @@
+import styles from '../page.module.css';
+
 export function AboutPage() {
   return (
-    <section className="page-shell">
-      <div className="page-intro">
-        <h1 className="page-title">О проекте</h1>
-        <p className="page-lead">
+    <section className={styles.page}>
+      <div className={styles.intro}>
+        <h1 className={styles.title}>О проекте</h1>
+        <p className={styles.lead}>
           Проект развивается как компактное SPA-приложение с прицелом на понятную архитектуру,
           хорошую производительность и дальнейшее развитие клиентской части.
         </p>

--- a/src/pages/CoursesPage/index.tsx
+++ b/src/pages/CoursesPage/index.tsx
@@ -5,6 +5,7 @@ import {StateMessage} from '../../components/StateMessage';
 import {getCourses} from '../../modules/courses/api';
 import {CourseCard} from '../../modules/courses/components/CourseCard';
 import type {CourseListItem} from '../../modules/courses/types';
+import styles from '../page.module.css';
 
 export function CoursesPage() {
   const [courses, setCourses] = useState<CourseListItem[]>([]);
@@ -69,20 +70,20 @@ export function CoursesPage() {
   });
 
   return (
-    <section className="page-shell">
-      <div className="page-intro">
-        <h1 className="page-title">Курсы</h1>
-        <p className="page-lead">
+    <section className={styles.page}>
+      <div className={styles.intro}>
+        <h1 className={styles.title}>Курсы</h1>
+        <p className={styles.lead}>
           Каталог показывает краткую информацию по каждому курсу, а полное содержание открывается на
           отдельной странице.
         </p>
       </div>
 
-      <div className="panel filter-panel">
-        <label className="field">
-          <span className="caption">Поиск по названию и описанию</span>
+      <div className={styles.filters}>
+        <label className={styles.field}>
+          <span className={styles.caption}>Поиск по названию и описанию</span>
           <input
-            className="control"
+            className={styles.control}
             type="search"
             value={query}
             onChange={event => setQuery(event.target.value)}
@@ -90,10 +91,10 @@ export function CoursesPage() {
           />
         </label>
 
-        <label className="field">
-          <span className="caption">Уровень курса</span>
+        <label className={styles.field}>
+          <span className={styles.caption}>Уровень курса</span>
           <select
-            className="control"
+            className={styles.control}
             value={selectedLevel}
             onChange={event => setSelectedLevel(event.target.value)}>
             <option value="">Все уровни</option>
@@ -112,7 +113,7 @@ export function CoursesPage() {
           description="Попробуй изменить поисковый запрос или сбросить фильтр по уровню."
         />
       ) : (
-        <div className="card-grid">
+        <div className={styles.grid}>
           {filteredCourses.map(course => (
             <CourseCard key={course.id} course={course} />
           ))}

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -1,9 +1,11 @@
+import styles from '../page.module.css';
+
 export function HomePage() {
   return (
-    <section className="page-shell">
-      <div className="page-intro">
-        <h1 className="page-title">Современный каталог учебных курсов</h1>
-        <p className="page-lead">
+    <section className={styles.page}>
+      <div className={styles.intro}>
+        <h1 className={styles.title}>Современный каталог учебных курсов</h1>
+        <p className={styles.lead}>
           Courseboard React показывает, как может выглядеть легкое SPA-приложение с роутингом,
           модульной структурой, mock API и подготовкой к реальному backend.
         </p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,177 +1,70 @@
-@import "tailwindcss";
-
-@theme {
-  --font-sans: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  --color-brand-50: #ccfbf1;
-  --color-brand-700: #0f766e;
-  --shadow-soft: 0 10px 30px rgba(15, 23, 42, 0.08);
-  --text-display: clamp(1.875rem, 4vw, 2.75rem);
-  --text-display--line-height: 1.1;
-  --radius-panel: 1.5rem;
-  --container-page: 70rem;
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #1f2937;
+  background: #f3f4f6;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  --page-max-width: 1120px;
+  --surface-color: #ffffff;
+  --surface-soft-color: #f9fafb;
+  --border-color: #d1d5db;
+  --text-primary-color: #111827;
+  --text-secondary-color: #4b5563;
+  --accent-color: #0f766e;
+  --accent-soft-color: #ccfbf1;
+  --shadow-color: rgba(15, 23, 42, 0.08);
 }
 
-@layer base {
-  * {
-    box-sizing: border-box;
-  }
-
-  html,
-  body,
-  #root {
-    min-height: 100%;
-    margin: 0;
-  }
-
-  body {
-    min-width: 320px;
-    background: #f3f4f6;
-    color: #111827;
-  }
-
-  a {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  img {
-    display: block;
-    max-width: 100%;
-  }
-
-  button,
-  input,
-  textarea,
-  select {
-    font: inherit;
-  }
+* {
+  box-sizing: border-box;
 }
 
-@layer components {
-  .layout-shell {
-    @apply min-h-screen;
-  }
+html,
+body,
+#root {
+  min-height: 100%;
+  margin: 0;
+}
 
-  .page-container {
-    @apply mx-auto w-full max-w-page px-4 py-6 pb-12 md:px-6 md:py-8 md:pb-16;
-  }
+body {
+  min-width: 320px;
+}
 
-  .header-shell {
-    @apply border-b border-slate-300 bg-white/90 backdrop-blur-xl;
-  }
+a {
+  color: inherit;
+  text-decoration: none;
+}
 
-  .header-inner {
-    @apply mx-auto w-full max-w-page px-4 py-4 md:flex md:items-center md:justify-between md:gap-6 md:px-6;
-  }
+img {
+  display: block;
+  max-width: 100%;
+}
 
-  .brand-mark {
-    @apply mb-3 block text-lg text-slate-900 md:mb-0 md:text-xl;
-  }
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
 
-  .nav-list {
-    @apply m-0 flex list-none flex-wrap gap-2 p-0;
-  }
+.layout {
+  min-height: 100vh;
+}
 
-  .nav-pill {
-    @apply inline-flex min-h-10 items-center rounded-full px-3.5 text-sm text-slate-600 transition-colors hover:bg-slate-50 hover:text-slate-900;
-  }
-
-  .nav-pill-active {
-    @apply bg-brand-50 text-brand-700;
-  }
-
-  .page-shell {
-    @apply grid gap-6;
-  }
-
-  .page-intro {
-    @apply grid gap-3;
-  }
-
-  .page-title {
-    @apply m-0 text-display text-slate-900;
-  }
-
-  .page-lead {
-    @apply m-0 max-w-3xl text-base text-slate-600;
-  }
-
-  .panel {
-    @apply rounded-panel border border-slate-300 bg-white;
-  }
-
-  .filter-panel {
-    @apply grid gap-3.5 p-5;
-  }
-
-  .field {
-    @apply grid gap-2;
-  }
-
-  .caption {
-    @apply text-slate-600;
-    font-size: 0.95rem;
-  }
-
-  .control {
-    @apply min-h-11 w-full border border-slate-300 bg-white px-3.5 text-slate-900;
-    border-radius: 14px;
-  }
-
-  .loader-panel {
-    @apply grid w-full justify-items-center gap-3 rounded-panel border border-dashed border-slate-300 bg-slate-50 px-5 py-8 text-center text-slate-600;
-  }
-
-  .loader-spinner {
-    @apply h-7 w-7 animate-spin rounded-full border-3 border-slate-300 border-t-brand-700;
-  }
-
-  .state-panel {
-    @apply rounded-panel border border-slate-300 bg-white px-5 py-6;
-  }
-
-  .state-title {
-    @apply mb-2.5 text-xl text-slate-900;
-  }
-
-  .state-text {
-    @apply m-0 text-slate-600;
-  }
-
-  .action-button {
-    @apply mt-4 cursor-pointer rounded-2xl bg-brand-700 px-4 py-3 text-white transition-opacity hover:opacity-90;
-  }
-
-  .card-grid {
-    @apply grid gap-4 md:grid-cols-2 md:gap-5 xl:grid-cols-3;
-  }
-
-  .course-card {
-    @apply h-full rounded-panel border border-slate-300 bg-white p-5 shadow-soft;
-  }
-
-  .course-title {
-    @apply mb-3 text-lg;
-  }
-
-  .course-link {
-    @apply text-slate-900 transition-colors hover:text-brand-700;
-  }
-
-  .course-summary {
-    @apply mb-4 text-slate-600;
-  }
-
-  .course-level {
-    @apply text-sm text-brand-700;
-  }
+.content {
+  width: min(100% - 32px, var(--page-max-width));
+  margin: 0 auto;
+  padding: 24px 0 48px;
 }
 
 @media (min-width: 768px) {
-  @layer components {
-    .filter-panel {
-      grid-template-columns: minmax(0, 2fr) minmax(220px, 1fr);
-      align-items: end;
-    }
+  .content {
+    width: min(100% - 48px, var(--page-max-width));
+    padding: 32px 0 64px;
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
-import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()]
+  plugins: [react()]
 });


### PR DESCRIPTION
Closes #16

Что сделано:
- проект возвращен с Tailwind на CSS Modules
- сохранен короткий локальный нейминг классов без BEM
- восстановлен обычный global.css как базовый слой
- сняты зависимости Tailwind и Vite-плагин
- сохранено локальное изменение docker-compose.yml

Проверка:
- docker exec courseboardreact_app npm run build